### PR TITLE
Fixed improper return statements introduced in last bug fix.

### DIFF
--- a/SDI12.cpp
+++ b/SDI12.cpp
@@ -375,12 +375,12 @@ void SDI12::setState(uint8_t state){
     pinMode(_dataPin,OUTPUT);
     digitalWrite(_dataPin,LOW);
     *digitalPinToPCMSK(_dataPin) &= ~(1<<digitalPinToPCMSKbit(_dataPin));
-    return(); 
+    return; 
   }
   if(state == TRANSMITTING){
     pinMode(_dataPin,OUTPUT);
     noInterrupts(); 			// supplied by Arduino.h, same as cli()
-    return(); 
+    return; 
   }
   if(state == LISTENING) {
     digitalWrite(_dataPin,LOW);


### PR DESCRIPTION
Return statements should  be of the form “return” not “return()”
