### PR TITLE
Fix string usage and add other string types

### DIFF
--- a/src/SDI12.cpp
+++ b/src/SDI12.cpp
@@ -591,7 +591,7 @@ void SDI12::writeChar(uint8_t out)
 }
 
 //	4.3	- this function sends out the characters of the String cmd, one by one
-void SDI12::sendCommand(String cmd)
+void SDI12::sendCommand(String &cmd)
 {
   myDiagPrintLn(String("sendCommand - cmd ") + cmd);
   wakeSensors();							// wake up sensors
@@ -601,9 +601,29 @@ void SDI12::sendCommand(String cmd)
   setState(LISTENING); 						// listen for reply
 }
 
+void SDI12::sendCommand(const char *cmd)
+{
+  myDiagPrintLn(String("sendCommand - cmd ") + cmd);
+  wakeSensors();							// wake up sensors
+  for (int unsigned i = 0; i < strlen(cmd); i++){
+	writeChar(cmd[i]); 						// write each characters
+  }
+  setState(LISTENING); 						// listen for reply
+}
+
+void SDI12::sendCommand(FlashString cmd)
+{
+  myDiagPrintLn(String("sendCommand - cmd ") + cmd);
+  wakeSensors();							// wake up sensors
+  for (int unsigned i = 0; i < strlen_P((PGM_P)cmd); i++){
+	writeChar((char)pgm_read_byte((const char *)cmd + i)); 						// write each characters
+  }
+  setState(LISTENING); 						// listen for reply
+}
+
 //  4.4 - this function sets up for a response, then sends out the characters
 //		  of String resp, one by one (for slave)
-void SDI12::sendResponse(String resp)
+void SDI12::sendResponse(String &resp)
 {
   myDiagPrintLn(String("sendResponse - resp ") + resp);
   setState(TRANSMITTING);					// 8.33 ms marking before response
@@ -611,6 +631,30 @@ void SDI12::sendResponse(String resp)
   delayMicroseconds(8330);
   for (int unsigned i = 0; i < resp.length(); i++){
 	writeChar(resp[i]); 						// write each characters
+  }
+  setState(LISTENING); 						// return to listening state
+}
+
+void SDI12::sendResponse(const char *resp)
+{
+  myDiagPrintLn(String("sendResponse - resp ") + resp);
+  setState(TRANSMITTING);					// 8.33 ms marking before response
+  digitalWrite(_dataPin, LOW);
+  delayMicroseconds(8330);
+  for (int unsigned i = 0; i < strlen(resp); i++){
+	writeChar(resp[i]); 						// write each characters
+  }
+  setState(LISTENING); 						// return to listening state
+}
+
+void SDI12::sendResponse(FlashString resp)
+{
+  myDiagPrintLn(String("sendResponse - resp ") + resp);
+  setState(TRANSMITTING);					// 8.33 ms marking before response
+  digitalWrite(_dataPin, LOW);
+  delayMicroseconds(8330);
+  for (int unsigned i = 0; i < strlen_P((PGM_P)resp); i++){
+	writeChar((char)pgm_read_byte((const char *)resp + i)); 						// write each characters
   }
   setState(LISTENING); 						// return to listening state
 }

--- a/src/SDI12.h
+++ b/src/SDI12.h
@@ -46,6 +46,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <Arduino.h>            // Arduino core library
 #include <Stream.h>				// Arduino Stream library
 
+typedef const __FlashStringHelper *FlashString;
+
 class SDI12 : public Stream
 {
 protected:
@@ -68,8 +70,12 @@ public:
 
   void forceHold(); 			// sets line state to HOLDING
   void forceListen(); 			// sets line state to LISTENING
-  void sendCommand(String cmd);	// sends the String cmd out on the data line
-  void sendResponse(String resp);	// sends the String resp out on the data line
+  void sendCommand(String &cmd);	// sends the String cmd out on the data line
+  void sendCommand(const char *cmd);	// sends the String cmd out on the data line
+  void sendCommand(FlashString cmd);	// sends the String cmd out on the data line
+  void sendResponse(String &resp);	// sends the String resp out on the data line
+  void sendResponse(const char *resp);	// sends the String resp out on the data line
+  void sendResponse(FlashString resp);	// sends the String resp out on the data line
 
   int available();			// returns the number of bytes available in buffer
   int peek();				// reveals next byte in buffer without consuming


### PR DESCRIPTION
`sendCommand` and `sendResponse` now pass the command/response argument as a `String` reference instead of cloning the `String` object to help reduce heap fragmentation by incorrect use of the abominable `String` class.

The functions have also been overloaded with parameter types of `const char *` and `FlashString` (the latter being a typedef of `__FlashStringHelper *` for convenience) to allow the use of the library by people who don't want their heap fragmenting by the forced use of the abominable `String` class.