### PR TITLE
Fix formatting of license so GitHub will recognize it

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
-## Software License Agreement (BSD-3 License)
+BSD 3-Clause License
 
-**Copyright (c) 2013, Stroud Water Research Center (SWRC) and the EnviroDIY Development Team.**
+Copyright (c) 2013, Stroud Water Research Center (SWRC) and the EnviroDIY Development Team.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,


### PR DESCRIPTION
GitHub uses the [licensee](https://github.com/benbalter/licensee) ruby gem to detect the license type of the repository. licensee [uses](https://github.com/benbalter/licensee/blob/master/docs/what-we-look-at.md#known-licenses) the license texts from [choosealicense.com](https://choosealicense.com/) so if the text of your license file differs from their license it will not be recognized. GitHub allows [filtering searches by license type](https://blog.github.com/2017-11-03-search-repositories-by-license/) and also [shows](https://help.github.com/articles/adding-a-license-to-a-repository/) the license type on the homepage of your repository and when viewing the license page but these features are only available when the license is recognized.