### PR TITLE
Update SDI12_boards.cpp

### DIFF
--- a/src/SDI12_boards.cpp
+++ b/src/SDI12_boards.cpp
@@ -107,22 +107,22 @@ static uint8_t preSDI12_TCCR1A;
 #if F_CPU == 16000000L
 
 void SDI12Timer::configSDI12TimerPrescale(void) {
-  preSDI12_TCCR1A = TCCR1A;
-  TCCR1A = 0b00001011;  // Set the prescaler to 1024
+  preSDI12_TCCR1A = TCCR1;
+  TCCR1 = 0b00001011;  // Set the prescaler to 1024
 }
 void SDI12Timer::resetSDI12TimerPrescale(void) {
-  TCCR1A = preSDI12_TCCR1A;
+  TCCR1 = preSDI12_TCCR1A;
 }
 
 
 #elif F_CPU == 8000000L
 
 void SDI12Timer::configSDI12TimerPrescale(void) {
-  preSDI12_TCCR1A = TCCR1A;
-  TCCR1A = 0b00001010;  // Set the prescaler to 512
+  preSDI12_TCCR1A = TCCR1;
+  TCCR1 = 0b00001010;  // Set the prescaler to 512
 }
 void SDI12Timer::resetSDI12TimerPrescale(void) {
-  TCCR1A = preSDI12_TCCR1A;
+  TCCR1 = preSDI12_TCCR1A;
 }
 #endif
 


### PR DESCRIPTION
Hey,

I think i found another bug in your lib using the ATtiny(85).

You set the prescaler for the timer on the register TCCR1A (chapter 13 in Attiny complete datasheet). This only works, when your Attiny is in the "ATtiny15 compatible mode" (can be set with fuses). If your Tiny is not in that mode (and I think it usually isnt) the prescaler is then wrong and the bits are banged way to fast.
Instead you need to write to the TCCR1 register (chapter 12 in Attiny complete datasheet). Then the 1200 baud rate is right and the sensor is responding. (Tested with Attiny85@8Mhz)

With best regards