### PR TITLE
fixed issue in slave example where some commands sent slave into unresponsive state

### DIFF
--- a/examples/h_SDI-12_slave_implementation/h_SDI-12_slave_implementation.ino
+++ b/examples/h_SDI-12_slave_implementation/h_SDI-12_slave_implementation.ino
@@ -39,6 +39,7 @@ int  state         = 0;
 #define WAIT 0
 #define INITIATE_CONCURRENT 1
 #define INITIATE_MEASUREMENT 2
+#define PROCESS_COMMAND 3                         
 
 // Create object by which to communicate with the SDI-12 bus on SDIPIN
 SDI12 slaveSDI12(DATA_PIN);
@@ -196,6 +197,7 @@ void loop() {
       // Character '!' indicates the end of an SDI-12 command; if the current
       // character is '!', stop listening and respond to the command
       if (charReceived == '!') {
+        state = PROCESS_COMMAND;                  
         // Command string is completed; do something with it
         parseSdi12Cmd(commandReceived, dValues);
         // Clear command string to reset for next command
@@ -245,6 +247,10 @@ void loop() {
       state = WAIT;
       slaveSDI12.forceListen();  // sets SDI-12 pin as input to prepare for incoming
                                  // message AGAIN
+      break;
+    case PROCESS_COMMAND:
+      state = WAIT;
+      slaveSDI12.forceListen();                         
       break;
   }
 }


### PR DESCRIPTION
This pull request fixes an issue in example: h_SDI-12_slave_implementation.ino

Previously sending some commands (eg: 5!) would lead to a call of forceHold() without a call to forceListen(). This would send the slave into an unresponsive state. 